### PR TITLE
Fix Pushbutton prop lens glow internal variables

### DIFF
--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_HVel_minus.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_HVel_minus.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_APHVELMINUS_ON
+		variableName = CUSTOM_FUSTEK_AP_HVEL_MINUS_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_HVel_plus.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_HVel_plus.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_APHVELPLUS_ON
+		variableName = CUSTOM_FUSTEK_AP_HVEL_PLUS_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Normal_minus.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Normal_minus.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_APNORMALMINUS_ON
+		variableName = CUSTOM_FUSTEK_AP_NORMAL_MINUS_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Normal_plus.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Normal_plus.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_APNORMALPLUS_ON
+		variableName = CUSTOM_FUSTEK_AP_NORMAL_PLUS_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Prograde.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Prograde.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_APPROGRADE_ON
+		variableName = CUSTOM_FUSTEK_AP_PROGRADE_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Radial_minus.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Radial_minus.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_APRADIALMINUS_ON
+		variableName = CUSTOM_FUSTEK_AP_RADIAL_MINUS_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Radial_plus.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Radial_plus.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_APRADIALPLUS_ON
+		variableName = CUSTOM_FUSTEK_AP_RADIAL_PLUS_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Retrograde.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Retrograde.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_APRETROGRADE_ON
+		variableName = CUSTOM_FUSTEK_AP_RETROGRADE_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Roll0.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Roll0.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_APROLL0_ON
+		variableName = CUSTOM_FUSTEK_AP_ROLL0_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Roll180.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Roll180.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_APROLL180_ON
+		variableName = CUSTOM_FUSTEK_AP_ROLL180_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Roll270.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Roll270.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_APROLL270_ON
+		variableName = CUSTOM_FUSTEK_AP_ROLL270_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Roll90.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_Roll90.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_APROLL90_ON
+		variableName = CUSTOM_FUSTEK_AP_ROLL90_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_RollOn.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_AP_RollOn.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_APROLL_ON
+		variableName = CUSTOM_FUSTEK_AP_ROLL_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_ATU_PushToTalk.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_ATU_PushToTalk.cfg
@@ -19,7 +19,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_ATUPTT_ON
+		variableName = CUSTOM_FUSTEK_ATU_PTT_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_CnW_Caution.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_CnW_Caution.cfg
@@ -19,7 +19,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_CNWCAUTION_ON
+		variableName = CUSTOM_FUSTEK_CNW_CAUTION_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_CnW_Decompress.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_CnW_Decompress.cfg
@@ -19,7 +19,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_CNWDECOMP_ON
+		variableName = CUSTOM_FUSTEK_CNW_DECOMP_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_CnW_Fire.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_CnW_Fire.cfg
@@ -19,7 +19,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_CNWFIRE_ON
+		variableName = CUSTOM_FUSTEK_CNW_FIRE_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_CnW_Test.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_CnW_Test.cfg
@@ -19,7 +19,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_CNWTEST_ON
+		variableName = CUSTOM_FUSTEK_CNW_TEST_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_CnW_ToxAtmos.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_CnW_ToxAtmos.cfg
@@ -19,7 +19,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_CNWTOXATMOS_ON
+		variableName = CUSTOM_FUSTEK_CNW_TOXATMOS_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_CnW_Warning.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_CnW_Warning.cfg
@@ -19,7 +19,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_CNWWARNING_ON
+		variableName = CUSTOM_FUSTEK_CNW_WARNING_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_Misc_Backlight.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_Misc_Backlight.cfg
@@ -19,7 +19,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_MISCBACKLIGHT_ON
+		variableName = CUSTOM_FUSTEK_MISC_BACKLIGHT_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_Misc_IntLight.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_Misc_IntLight.cfg
@@ -19,7 +19,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_MISCINTLIGHT_ON
+		variableName = CUSTOM_FUSTEK_MISC_INTLIGHT_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_Misc_IntLight.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_Misc_IntLight.cfg
@@ -19,7 +19,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_MISC_INTLIGHT_ON
+		variableName = CUSTOM_FUSTEK_MISC_INT_LIGHT_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_Misc_Vent.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_Misc_Vent.cfg
@@ -19,7 +19,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_MISCVENT_ON
+		variableName = CUSTOM_FUSTEK_MISC_VENT_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_Misc_ViewportDemist.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_Misc_ViewportDemist.cfg
@@ -19,7 +19,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_MISCVIEWPORTDEMIST_ON
+		variableName = CUSTOM_FUSTEK_MISC_VIEWPORT_DEMIST_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_Misc_ViewportDemist_Slave.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_Misc_ViewportDemist_Slave.cfg
@@ -19,7 +19,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_MISCVIEWPORTDEMISTSLAVE_ON
+		variableName = CUSTOM_FUSTEK_MISC_VIEWPORT_DEMIST_SLAVE_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_Misc_ViewportShutter.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_Misc_ViewportShutter.cfg
@@ -19,7 +19,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_MISCVIEWPORTSHUTTER_ON
+		variableName = CUSTOM_FUSTEK_MISC_VIEWPORT_SHUTTER_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_AntiNormal.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_AntiNormal.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_SASANTINORMAL_ON
+		variableName = CUSTOM_FUSTEK_SAS_ANTI_NORMAL_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_AntiTarget.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_AntiTarget.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_SASANTITARGET_ON
+		variableName = CUSTOM_FUSTEK_SAS_ANTI_TARGET_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_Maneuver.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_Maneuver.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_SASMANEUVER_ON
+		variableName = CUSTOM_FUSTEK_SAS_MANEUVER_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_Normal.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_Normal.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_SASNORMAL_ON
+		variableName = CUSTOM_FUSTEK_SAS_NORMAL_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_Prograde.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_Prograde.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_SASPROGRADE_ON
+		variableName = CUSTOM_FUSTEK_SAS_PROGRADE_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_RadialIn.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_RadialIn.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_SASRADIALIN_ON
+		variableName = CUSTOM_FUSTEK_SAS_RADIAL_IN_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_RadialOut.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_RadialOut.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_SASRADIALOUT_ON
+		variableName = CUSTOM_FUSTEK_SAS_RADIAL_OUT_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_Retrograde.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_Retrograde.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_SASRETROGRADE_ON
+		variableName = CUSTOM_FUSTEK_SAS_RETROGRADE_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_StabAssist.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_StabAssist.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_SASSTABASSIST_ON
+		variableName = CUSTOM_FUSTEK_SAS_STAB_ASSIST_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5

--- a/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_Target.cfg
+++ b/GameData/FusTek/Station Parts/Props/Controls/FusTek_Pushbutton_SAS_Target.cfg
@@ -25,7 +25,7 @@ PROP
 	MODULE
 	{
 		name = JSIVariableAnimator
-		variableName = CUSTOM_FUSTEK_SASTARGET_ON
+		variableName = CUSTOM_FUSTEK_SAS_TARGET_ON
 		scale = 0,1
 		threshold = 0.5,1.1
 		refreshRate = 5


### PR DESCRIPTION
For #2.

Added underscores to improve readability of the internal variables used to track the button's "on" state.