### PR TITLE
Tweak ModuleManager Patchs to include Resupply Module

### DIFF
--- a/GameData/FusTek/Station Parts/Parts/MM_configs/FusTek_MMPatch_ConnectedLivingSpaces.cfg
+++ b/GameData/FusTek/Station Parts/Parts/MM_configs/FusTek_MMPatch_ConnectedLivingSpaces.cfg
@@ -125,3 +125,9 @@
 		impassablenodes = top
 	}
 }
+
+@PART[FusTekResupplyModule]:NEEDS[ConnectedLivingSpace]{
+	%MODULE[ModuleConnectedLivingSpace] {
+		%passable = true
+	}
+}

--- a/GameData/FusTek/Station Parts/Parts/MM_configs/FusTek_MMPatch_ConnectedLivingSpaces.cfg
+++ b/GameData/FusTek/Station Parts/Parts/MM_configs/FusTek_MMPatch_ConnectedLivingSpaces.cfg
@@ -125,9 +125,3 @@
 		impassablenodes = top
 	}
 }
-
-@PART[FusTekResupplyModule]:NEEDS[ConnectedLivingSpace]{
-	%MODULE[ModuleConnectedLivingSpace] {
-		%passable = true
-	}
-}

--- a/GameData/FusTek/Station Parts/Parts/MM_configs/Fusteck_MMPatch_MechJeb.cfg
+++ b/GameData/FusTek/Station Parts/Parts/MM_configs/Fusteck_MMPatch_MechJeb.cfg
@@ -22,5 +22,28 @@
 			MechJebModuleRendezvousGuidance { unlockTechs = advUnmanned }
 		}
 	}
-} 
+}
+
+@PART[FusTekResupplyModule]:NEEDS[MechJeb2] {
+	%MODULE[MechJebCore] {
+		MechJebLocalSettings {
+			MechJebModuleCustomWindowEditor { unlockTechs = flightControl }
+			MechJebModuleSmartASS { unlockTechs = flightControl }
+			MechJebModuleManeuverPlanner { unlockTechs = advFlightControl }
+			MechJebModuleNodeEditor { unlockTechs = advFlightControl }
+			MechJebModuleTranslatron { unlockTechs = advFlightControl }
+			MechJebModuleWarpHelper { unlockTechs = advFlightControl }
+			MechJebModuleAttitudeAdjustment { unlockTechs = advFlightControl }
+			MechJebModuleThrustWindow { unlockTechs = advFlightControl }
+			MechJebModuleRCSBalancerWindow { unlockTechs = advFlightControl }
+			MechJebModuleRoverWindow { unlockTechs = fieldScience }
+			MechJebModuleAscentGuidance { unlockTechs = unmannedTech }
+			MechJebModuleLandingGuidance { unlockTechs = unmannedTech }
+			MechJebModuleSpaceplaneGuidance { unlockTechs = unmannedTech }
+			MechJebModuleDockingGuidance { unlockTechs = advUnmanned }
+			MechJebModuleRendezvousAutopilotWindow { unlockTechs = advUnmanned }
+			MechJebModuleRendezvousGuidance { unlockTechs = advUnmanned }
+		}
+	}
+}  
 

--- a/GameData/FusTek/Station Parts/Parts/MM_configs/Fusteck_MMPatch_RemoteTech.cfg
+++ b/GameData/FusTek/Station Parts/Parts/MM_configs/Fusteck_MMPatch_RemoteTech.cfg
@@ -6,3 +6,7 @@
 	}
 }
 
+//Add RemoteTech to Resupply Module
+@PART[FusTekResupplyModule]:NEEDS[RemoteTech]{
+	%MODULE[ModuleSPU] {}
+}


### PR DESCRIPTION
Tweak ModuleManager Patchs. 
- Add ConnectLivingSpace support in the Resupply Module.
- Add RemoteTech support in the Resupply Module.
- Add MechJeb support in the Resupply Module.